### PR TITLE
Added PostgreSQL layer.

### DIFF
--- a/Dockerfile.postgresql
+++ b/Dockerfile.postgresql
@@ -1,0 +1,18 @@
+FROM amazonlinux
+
+WORKDIR /root
+
+ARG VERSION=9.2.24
+
+RUN yum -y update && yum install -y make gcc-c++ ncurses-devel openssl-devel python-devel wget tar gzip which zip
+
+RUN wget -q https://ftp.postgresql.org/pub/source/v${VERSION}/postgresql-${VERSION}.tar.gz
+
+RUN tar xzf postgresql-${VERSION}.tar.gz
+RUN cd postgresql-${VERSION}; ./configure --without-readline --prefix=/opt; make \
+    && make -C src/bin install \
+    && make -C src/include install \
+    && make -C src/interfaces install
+
+RUN cp /usr/lib64/libncurses.so.6 /usr/lib64/libtinfo.so.6 /opt/lib/
+RUN cd /opt; strip bin/* lib/*; rm lib/*.a; zip -9r /root/postgresql-${VERSION}-layer.zip bin lib share

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 MYSQL_VERSION = 8.0.18
+POSTGRESQL_VERSION = 10.14
 
-all: mysql-$(MYSQL_VERSION)-layer.zip mariadb-layer.zip
+all: mysql-$(MYSQL_VERSION)-layer.zip mariadb-layer.zip postgresql-$(POSTGRESQL_VERSION)-layer.zip
 
 mysql: mysql-$(MYSQL_VERSION)-layer.zip
 mariadb: mariadb-layer.zip
+postgresql: postgresql-$(POSTGRESQL_VERSION)-layer.zip
 
 mysql-$(MYSQL_VERSION)-layer.zip:
 	docker build -f Dockerfile.mysql . -t mysql-layer --build-arg VERSION=$(MYSQL_VERSION)
@@ -13,6 +15,9 @@ mariadb-layer.zip:
 	docker build -f Dockerfile.mariadb . -t mariadb-layer
 	docker container cp $(shell docker container create mariadb-layer):/root/mariadb-layer.zip .
 
+postgresql-$(POSTGRESQL_VERSION)-layer.zip:
+        docker build -f Dockerfile.postgresql . -t postgresql-layer --build-arg VERSION=$(POSTGRESQL_VERSION)
+        docker container cp $(shell docker container create postgresql-layer):/root/postgresql-$(POSTGRESQL_VERSION)-layer.zip .
+
 clean:
 	rm -f *.zip
-

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
-# AWS Lambda Layers for MySQL and MariaDB commands
+# AWS Lambda Layers for MySQL, MariaDB and PostgreSQL commands
 
-These layers add the `mysql` client commands in the form of a layer to be used with [AWS Lambda](https://aws.amazon.com/lambda/).
+These layers add the `mysql` and/ or `psql` client commands in the form of a layer to be used with [AWS Lambda](https://aws.amazon.com/lambda/).
 
-This is useful for Lambda functions that need to run MySQL commands to quickly import data to a RDS server, for example. It can be easier than using the MySQL API in the language of your choice. Particularly useful in coordination with a [Bash lambda](https://github.com/gkrizek/bash-lambda-layer) layer.
+This is useful for Lambda functions that need to run MySQL or PostgreSQL commands to quickly import data to a RDS server, for example. It can be easier than using the MySQL API in the language of your choice. Particularly useful in coordination with a [Bash lambda](https://github.com/gkrizek/bash-lambda-layer) layer.
 
 The layers (in the form of zip files) are built in Docker using the official AmazonLinux image, to match the typicial Lambda runtime environment.
 
 - The MySQL layer is built from the official source (v8.0.18)
 - The MariaDB layer is built from the binary files in the current `mariadb` AmazonLinux package.
+- The PostgreSQL layer is built from the official source (v9.2.24)
 
 ## Download
 
@@ -19,8 +20,9 @@ If you have a working Docker setup, you just need to enter `make` to build both 
 
 - `make mysql` builds the MySQL variant from source.
 - `make mariadb` builds the MariaDB variant from the pre-built packages.
+- `make postgresql` builds the MySQL variant from source.
 
-Note that the MySQL 8.0 variant takes considerably longer to build from source.
+Note that the MySQL 8.0 and PostgreSQL variants take considerably longer to build from source.
 
 ### Author
 


### PR DESCRIPTION
I needed to make this today, and I used your repo as a guide.  I figured, even though the name of your repo is `mysql-lambda` - you may still want to make use of it?  Anyways, pushing up here so it's then your choice.

It only installs the necessary client executables and libraries.  None of the docs or server code is included (hence, the multiple `make install` commands).

NOTE too ... I've left in the later version number for RDS Aurora (i.e. current version), and the Dockerfile has the current amazonlinux version (although obviously, both will build from source).