### PR TITLE
Added MongoDB layer.

### DIFF
--- a/Dockerfile.mongodb
+++ b/Dockerfile.mongodb
@@ -1,0 +1,15 @@
+FROM amazonlinux
+
+WORKDIR /root
+
+ARG VERSION=100.4.0
+
+RUN yum -y update && yum install -y binutils gzip ncurses-devel tar wget zip
+
+RUN wget -q https://fastdl.mongodb.org/tools/db/mongodb-database-tools-amazon2-x86_64-${VERSION}.tgz
+RUN tar xzf mongodb-database-tools-amazon2-x86_64-${VERSION}.tgz
+
+RUN mkdir -p /opt/lib
+RUN cp -rp mongodb-database-tools-amazon2-x86_64-${VERSION}/bin /opt/
+RUN cp /usr/lib64/libncurses.so.6 /usr/lib64/libtinfo.so.6 /opt/lib/
+RUN cd /opt; strip bin/* lib/*; rm lib/*.a; zip -9r /root/mongodb-tools-${VERSION}-layer.zip bin lib

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 MYSQL_VERSION = 8.0.18
 POSTGRESQL_VERSION = 10.14
+MONGODB_VERSION = 100.4.0
 
-all: mysql-$(MYSQL_VERSION)-layer.zip mariadb-layer.zip postgresql-$(POSTGRESQL_VERSION)-layer.zip
+all: mysql-$(MYSQL_VERSION)-layer.zip mariadb-layer.zip postgresql-$(POSTGRESQL_VERSION)-layer.zip mongodb-tools-$(MONGODB_VERSION)-layer.zip
 
 mysql: mysql-$(MYSQL_VERSION)-layer.zip
 mariadb: mariadb-layer.zip
 postgresql: postgresql-$(POSTGRESQL_VERSION)-layer.zip
+mongodb: mongodb-tools-$(MONGODB_VERSION)-layer.zip
 
 mysql-$(MYSQL_VERSION)-layer.zip:
 	docker build -f Dockerfile.mysql . -t mysql-layer --build-arg VERSION=$(MYSQL_VERSION)
@@ -16,8 +18,12 @@ mariadb-layer.zip:
 	docker container cp $(shell docker container create mariadb-layer):/root/mariadb-layer.zip .
 
 postgresql-$(POSTGRESQL_VERSION)-layer.zip:
-        docker build -f Dockerfile.postgresql . -t postgresql-layer --build-arg VERSION=$(POSTGRESQL_VERSION)
-        docker container cp $(shell docker container create postgresql-layer):/root/postgresql-$(POSTGRESQL_VERSION)-layer.zip .
+	docker build -f Dockerfile.postgresql . -t postgresql-layer --build-arg VERSION=$(POSTGRESQL_VERSION)
+	docker container cp $(shell docker container create postgresql-layer):/root/postgresql-$(POSTGRESQL_VERSION)-layer.zip .
+
+mongodb-tools-$(MONGODB_VERSION)-layer.zip:
+	docker build -f Dockerfile.mongodb . -t mongodb-layer --build-arg VERSION=$(MONGODB_VERSION)
+	docker container cp $(shell docker container create mongodb-layer):/root/mongodb-tools-$(MONGODB_VERSION)-layer.zip .
 
 clean:
 	rm -f *.zip

--- a/README.md
+++ b/README.md
@@ -1,14 +1,15 @@
-# AWS Lambda Layers for MySQL, MariaDB and PostgreSQL commands
+# AWS Lambda Layers for MySQL, MariaDB, PostgreSQL and MongoDB Tools commands
 
-These layers add the `mysql` and/ or `psql` client commands in the form of a layer to be used with [AWS Lambda](https://aws.amazon.com/lambda/).
+These layers add the `mysql`, `psql`, `mongodump`, `mongorestore` client commands in the form of a layer to be used with [AWS Lambda](https://aws.amazon.com/lambda/).
 
-This is useful for Lambda functions that need to run MySQL or PostgreSQL commands to quickly import data to a RDS server, for example. It can be easier than using the MySQL API in the language of your choice. Particularly useful in coordination with a [Bash lambda](https://github.com/gkrizek/bash-lambda-layer) layer.
+This is useful for Lambda functions that need to run MySQL, PostgreSQL or MongoDB commands to quickly import data to a RDS server, for example. It can be easier than using the MySQL API in the language of your choice. Particularly useful in coordination with a [Bash lambda](https://github.com/gkrizek/bash-lambda-layer) layer.
 
 The layers (in the form of zip files) are built in Docker using the official AmazonLinux image, to match the typicial Lambda runtime environment.
 
 - The MySQL layer is built from the official source (v8.0.18)
 - The MariaDB layer is built from the binary files in the current `mariadb` AmazonLinux package.
 - The PostgreSQL layer is built from the official source (v9.2.24)
+- The MongoDB Tools layer is built from the official source (v100.4.0)
 
 ## Download
 
@@ -20,9 +21,10 @@ If you have a working Docker setup, you just need to enter `make` to build both 
 
 - `make mysql` builds the MySQL variant from source.
 - `make mariadb` builds the MariaDB variant from the pre-built packages.
-- `make postgresql` builds the MySQL variant from source.
+- `make postgresql` builds the PostgreSQL variant from source.
+- `make mongodb` builds the MongoDB variant from source.
 
-Note that the MySQL 8.0 and PostgreSQL variants take considerably longer to build from source.
+Note that the MySQL 8.0, PostgreSQL and MongoDB variants take considerably longer to build from source.
 
 ### Author
 


### PR DESCRIPTION
Similarly to https://github.com/megastep/mysql-lambda/pull/2 ... I needed a MongoDB Tools layer.  Figured I'd push it up in case you might want it?  It's been in production for a good 3 weeks now - seems to work great for our scheduled dumps.